### PR TITLE
Update hero publications count to 143

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,7 +194,7 @@
       <div class="hero-stats">
         <div><span class="stat-num">5,300<span class="unit">+</span></span><span class="stat-label">Citations</span></div>
         <div><span class="stat-num">34</span><span class="stat-label">h-index</span></div>
-        <div><span class="stat-num">80<span class="unit">+</span></span><span class="stat-label">Publications</span></div>
+        <div><span class="stat-num">143</span><span class="stat-label">Publications</span></div>
         <div><span class="stat-num">4</span><span class="stat-label">Live platforms</span></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Single-line update to the hero stats: publications count `80+` → `143`.

Reflects the actual publication record. No other changes.

## Test plan

- [ ] Open `index.html`, confirm the hero stats row reads "143 · Publications" (was "80+ · Publications")