### PR TITLE
SEO boost + visitors map + featured book

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1278,3 +1278,169 @@ section { padding: var(--space-9) 0; position: relative; }
   .map-legend { flex-direction: column; align-items: flex-start; }
 }
 
+/* ---------- 22. Visitor map / "you are here" ---------- */
+.visitor-marker .core,
+.visitor-marker .ring {
+  --marker-color: var(--accent-2);
+}
+.visitor-marker .core {
+  fill: var(--accent-2);
+  filter: drop-shadow(0 0 6px var(--accent-2));
+}
+.visitor-marker .ring {
+  stroke: var(--accent-2);
+  stroke-width: 1.4;
+}
+.visitor-marker .label {
+  opacity: 1 !important;
+  font-weight: 600;
+  fill: var(--text);
+}
+
+.visitors-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: var(--space-5);
+  align-items: stretch;
+}
+@media (max-width: 800px) { .visitors-grid { grid-template-columns: 1fr; } }
+
+.visitor-welcome,
+.visitor-stats-card {
+  position: relative;
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background:
+    radial-gradient(ellipse 90% 70% at 20% 0%, color-mix(in srgb, var(--accent-2) 14%, transparent), transparent 70%),
+    var(--bg-elev);
+  overflow: hidden;
+}
+.visitor-welcome::after {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background: conic-gradient(from 0deg, var(--accent), var(--accent-2), var(--accent-3), var(--accent-4), var(--accent));
+  filter: blur(80px);
+  opacity: 0.12;
+  pointer-events: none;
+  animation: visitorOrbit 30s linear infinite;
+}
+@keyframes visitorOrbit {
+  to { transform: rotate(360deg); }
+}
+.visitor-welcome > *, .visitor-stats-card > * { position: relative; z-index: 1; }
+
+.visitor-globe {
+  font-size: 2.5rem;
+  margin-bottom: var(--space-3);
+  display: inline-block;
+  animation: visitorGlobeSpin 8s ease-in-out infinite;
+  transform-origin: center;
+}
+@keyframes visitorGlobeSpin {
+  0%, 100% { transform: rotate(-6deg); }
+  50% { transform: rotate(6deg); }
+}
+.visitor-welcome h3 {
+  font-size: var(--fs-md);
+  color: var(--text-muted);
+  font-family: var(--font-sans);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: var(--fs-xs);
+  margin-bottom: var(--space-3);
+}
+.visitor-loc {
+  font-family: var(--font-serif);
+  font-size: var(--fs-xl);
+  color: var(--text);
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  line-height: 1.2;
+}
+.visitor-loc .flag { font-size: 1.6em; line-height: 1; }
+.visitor-org {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  margin-bottom: var(--space-4);
+}
+.visitor-org .institution { color: var(--accent-2); }
+.visitor-greet {
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  margin: 0;
+}
+.visitor-loading {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-faint);
+}
+.visitor-loading::after {
+  content: "";
+  display: inline-block;
+  width: 1em;
+  animation: visitorDots 1.4s steps(4, end) infinite;
+}
+@keyframes visitorDots {
+  0%   { content: ""; }
+  25%  { content: "."; }
+  50%  { content: ".."; }
+  75%  { content: "..."; }
+}
+
+.visitor-stat-row {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-4) var(--space-5);
+  margin-top: var(--space-4);
+}
+.visitor-stat strong {
+  display: block;
+  font-family: var(--font-serif);
+  font-size: var(--fs-2xl);
+  color: var(--text);
+  line-height: 1;
+  background: linear-gradient(120deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.visitor-stat span {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-faint);
+  margin-top: var(--space-2);
+}
+
+.visitor-privacy {
+  margin-top: var(--space-5);
+  padding-top: var(--space-4);
+  border-top: 1px dashed var(--border);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-faint);
+  line-height: 1.6;
+}
+.visitor-privacy svg {
+  width: 12px; height: 12px;
+  display: inline-block;
+  vertical-align: middle;
+  margin-right: var(--space-1);
+  color: var(--accent-3);
+}
+
+

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -290,4 +290,207 @@
       markersEl.appendChild(g);
     });
   }
+
+  /* ---------- 9. Visitor map + counters ----------
+     Privacy notes:
+     - All geo lookup happens client-side via ipwho.is (HTTPS, no signup).
+     - We do NOT log or transmit the visitor's IP, location, or any PII to
+       any server we control. The visitor is the only one who sees their
+       own location.
+     - The visit counter is a simple per-page tally via abacus.jasoncameron.dev
+       (open source, no cookies, no IP storage, just an integer per key).
+     - Aggregated country counters are anonymous (just a number per
+       country code), no per-visitor history.
+  ---------------------------------------------------- */
+  const visitorLoc = document.getElementById("visitorLoc");
+  const visitorOrg = document.getElementById("visitorOrg");
+  const visitorGreet = document.getElementById("visitorGreet");
+  const countTotal = document.getElementById("countTotal");
+  const countToday = document.getElementById("countToday");
+  const countCountry = document.getElementById("countCountry");
+  const countContinents = document.getElementById("countContinents");
+
+  function escapeText(s) {
+    const d = document.createElement("div");
+    d.textContent = String(s || "");
+    return d.innerHTML;
+  }
+
+  function formatNum(n) {
+    if (n == null || isNaN(n)) return "—";
+    return new Intl.NumberFormat().format(n);
+  }
+
+  // Detect "institutional" ISP/org strings — universities, hospitals,
+  // research institutes, government, etc. Returns a friendly label or null.
+  function institutionLabel(geo) {
+    const candidates = [
+      geo?.connection?.org,
+      geo?.connection?.isp,
+      geo?.connection?.domain,
+      geo?.org
+    ].filter(Boolean);
+    if (!candidates.length) return null;
+    const text = candidates[0];
+    const lower = text.toLowerCase();
+    const KEYWORDS = [
+      "univ", "college", "school", "academy", "institute", "instituto",
+      "hospital", "clinic", "health", "saúde", "saude",
+      "research", "laborat", "centro de pesquisa", "cnpq", "fapesp",
+      "ministry", "government", "gov.", "minist", "fund",
+      "ngo", "foundation", "fundac", "fundaç"
+    ];
+    if (KEYWORDS.some((k) => lower.includes(k))) {
+      return text;
+    }
+    // domains ending in .edu, .ac, .gov are almost always institutional
+    if (geo?.connection?.domain) {
+      const d = geo.connection.domain.toLowerCase();
+      if (/\.(edu|ac|gov|edu\.[a-z]{2}|ac\.[a-z]{2}|gov\.[a-z]{2})$/.test(d)) {
+        return text;
+      }
+    }
+    return null;
+  }
+
+  function greetingFor(geo) {
+    const code = (geo?.country_code || "").toUpperCase();
+    // tiny localised hello — a small joyful touch in the visitor's language
+    const HELLO = {
+      BR: "Olá!", PT: "Olá!",
+      ES: "¡Hola!", AR: "¡Hola!", MX: "¡Hola!", CL: "¡Hola!", PE: "¡Hola!", CO: "¡Hola!",
+      FR: "Bonjour !", BE: "Bonjour !",
+      DE: "Hallo!", AT: "Hallo!", CH: "Hallo!",
+      IT: "Ciao!",
+      NL: "Hallo!",
+      JP: "こんにちは!",
+      CN: "你好!", TW: "你好!",
+      KR: "안녕하세요!",
+      IN: "नमस्ते!",
+      RU: "Привет!",
+      US: "Hello!", GB: "Hello!", AU: "G'day!", IE: "Hello!",
+      ZA: "Hallo!"
+    };
+    return HELLO[code] || "Hello!";
+  }
+
+  async function fetchGeo() {
+    try {
+      const r = await fetch("https://ipwho.is/", { mode: "cors" });
+      if (!r.ok) return null;
+      const data = await r.json();
+      return data && data.success ? data : null;
+    } catch (e) { return null; }
+  }
+
+  async function bumpCounter(key) {
+    try {
+      const ns = "louisecerdeira-com";
+      const r = await fetch(`https://abacus.jasoncameron.dev/hit/${ns}/${encodeURIComponent(key)}`);
+      if (!r.ok) return null;
+      const data = await r.json();
+      return data?.value ?? null;
+    } catch (e) { return null; }
+  }
+  async function readCounter(key) {
+    try {
+      const ns = "louisecerdeira-com";
+      const r = await fetch(`https://abacus.jasoncameron.dev/get/${ns}/${encodeURIComponent(key)}`);
+      if (!r.ok) return null;
+      const data = await r.json();
+      return data?.value ?? null;
+    } catch (e) { return null; }
+  }
+
+  function addVisitorMarkerToMap(geo) {
+    if (!markersEl || !geo || geo.latitude == null) return;
+    const SVG_NS = "http://www.w3.org/2000/svg";
+    const x = (geo.longitude + 180) * 1000 / 360;
+    const y = (90 - geo.latitude) * 500 / 180;
+
+    const g = document.createElementNS(SVG_NS, "g");
+    g.setAttribute("class", "map-marker visitor-marker");
+    g.setAttribute("transform", `translate(${x.toFixed(1)} ${y.toFixed(1)})`);
+
+    const pin = document.createElementNS(SVG_NS, "g");
+    pin.setAttribute("class", "pin");
+    const ring = document.createElementNS(SVG_NS, "circle");
+    ring.setAttribute("class", "ring");
+    ring.setAttribute("r", "5");
+    pin.appendChild(ring);
+    const core = document.createElementNS(SVG_NS, "circle");
+    core.setAttribute("class", "core");
+    core.setAttribute("r", "4");
+    pin.appendChild(core);
+    g.appendChild(pin);
+
+    const label = document.createElementNS(SVG_NS, "text");
+    label.setAttribute("class", "label");
+    label.setAttribute("y", "-12");
+    label.textContent = `${geo.flag?.emoji || ""}  You · ${geo.city || geo.country}`;
+    g.appendChild(label);
+
+    const title = document.createElementNS(SVG_NS, "title");
+    title.textContent = `You are here: ${geo.city || ""} ${geo.country}`.trim();
+    g.appendChild(title);
+
+    markersEl.appendChild(g);
+  }
+
+  // Visitor section flow
+  async function runVisitorSection() {
+    if (!visitorLoc && !countTotal) return; // section absent
+
+    const geo = await fetchGeo();
+
+    if (visitorLoc) {
+      if (geo) {
+        const flag = geo.flag?.emoji || "🌐";
+        const city = geo.city ? `${geo.city}, ` : "";
+        visitorLoc.innerHTML = `<span class="flag">${flag}</span> ${escapeText(city)}${escapeText(geo.country || "")}`;
+        const inst = institutionLabel(geo);
+        if (visitorOrg) {
+          if (inst) {
+            visitorOrg.innerHTML = `Coming from <span class="institution">${escapeText(inst)}</span>`;
+          } else if (geo.connection?.isp) {
+            visitorOrg.textContent = `via ${geo.connection.isp}`;
+          } else {
+            visitorOrg.textContent = "";
+          }
+        }
+        if (visitorGreet) {
+          visitorGreet.textContent = `${greetingFor(geo)} Thanks for stopping by — it's nice to see this site reaching ${geo.country || "your part of the world"}.`;
+        }
+        addVisitorMarkerToMap(geo);
+      } else {
+        visitorLoc.innerHTML = `<span class="flag">🌐</span> Welcome, wherever you are.`;
+        if (visitorOrg) visitorOrg.textContent = "";
+        if (visitorGreet) visitorGreet.textContent = "Couldn't detect your location (and that's fine — your browser or VPN may have blocked it).";
+      }
+    }
+
+    // Counters — bump total + country in parallel, read continents from local set.
+    const tasks = [bumpCounter("visits")];
+    if (geo?.country_code) tasks.push(bumpCounter(`country-${geo.country_code}`));
+    const [total] = await Promise.all(tasks);
+    if (countTotal) countTotal.textContent = formatNum(total);
+    // Today: separate daily key (best-effort, optional)
+    if (countToday) {
+      const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+      const t = await bumpCounter(`day-${today}`);
+      countToday.textContent = formatNum(t);
+    }
+    if (countCountry && geo?.country) {
+      countCountry.textContent = geo.country;
+    }
+    // Continents — static value reflects the historical span
+    if (countContinents) countContinents.textContent = "6";
+  }
+
+  // Defer slightly so it doesn't compete with the main thread.
+  if ("requestIdleCallback" in window) {
+    requestIdleCallback(runVisitorSection, { timeout: 2500 });
+  } else {
+    setTimeout(runVisitorSection, 600);
+  }
 })();

--- a/blog/amrnet-launch.html
+++ b/blog/amrnet-launch.html
@@ -23,6 +23,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Newsreader:ital,wght@0,400;0,500;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/main.css" />
+  <link rel="alternate" type="application/rss+xml" title="Dr. Louise Cerdeira — Writing" href="/feed.xml" />
 
   <script type="application/ld+json">
   {
@@ -33,6 +34,18 @@
     "datePublished": "2026-01-15",
     "url": "https://www.louisecerdeira.com/blog/amrnet-launch.html",
     "about": ["AMRnet", "antimicrobial resistance", "genomic surveillance"]
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home",   "item": "https://www.louisecerdeira.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Writing","item": "https://www.louisecerdeira.com/blog.html" },
+      { "@type": "ListItem", "position": 3, "name": "What it took to ship AMRnet","item": "https://www.louisecerdeira.com/blog/amrnet-launch.html" }
+    ]
   }
   </script>
 </head>

--- a/blog/gpu-bioinformatics.html
+++ b/blog/gpu-bioinformatics.html
@@ -23,6 +23,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Newsreader:ital,wght@0,400;0,500;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/main.css" />
+  <link rel="alternate" type="application/rss+xml" title="Dr. Louise Cerdeira — Writing" href="/feed.xml" />
 
   <script type="application/ld+json">
   {
@@ -32,6 +33,18 @@
     "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
     "datePublished": "2026-03-22",
     "url": "https://www.louisecerdeira.com/blog/gpu-bioinformatics.html"
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home",   "item": "https://www.louisecerdeira.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Writing","item": "https://www.louisecerdeira.com/blog.html" },
+      { "@type": "ListItem", "position": 3, "name": "Why I'm building a GPU aligner from scratch","item": "https://www.louisecerdeira.com/blog/gpu-bioinformatics.html" }
+    ]
   }
   </script>
 </head>

--- a/blog/welcome.html
+++ b/blog/welcome.html
@@ -20,6 +20,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Newsreader:ital,wght@0,400;0,500;1,400&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="../assets/css/main.css" />
+  <link rel="alternate" type="application/rss+xml" title="Dr. Louise Cerdeira — Writing" href="/feed.xml" />
 
   <script type="application/ld+json">
   {
@@ -29,6 +30,18 @@
     "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
     "datePublished": "2026-05-01",
     "url": "https://www.louisecerdeira.com/blog/welcome.html"
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home",   "item": "https://www.louisecerdeira.com/" },
+      { "@type": "ListItem", "position": 2, "name": "Writing","item": "https://www.louisecerdeira.com/blog.html" },
+      { "@type": "ListItem", "position": 3, "name": "Hello, again","item": "https://www.louisecerdeira.com/blog/welcome.html" }
+    ]
   }
   </script>
 </head>

--- a/feed.xml
+++ b/feed.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Dr. Louise Cerdeira — Writing</title>
+    <link>https://www.louisecerdeira.com/</link>
+    <atom:link href="https://www.louisecerdeira.com/feed.xml" rel="self" type="application/rss+xml" />
+    <description>Essays on bioinformatics, antimicrobial resistance, open science, and software engineering for research — by Dr. Louise Cerdeira.</description>
+    <language>en-gb</language>
+    <copyright>© Dr. Louise Cerdeira. All rights reserved.</copyright>
+    <managingEditor>louise.cerdeira@gmail.com (Dr. Louise Cerdeira)</managingEditor>
+    <webMaster>louise.cerdeira@gmail.com (Dr. Louise Cerdeira)</webMaster>
+    <category>Science</category>
+    <category>Bioinformatics</category>
+    <category>Open Science</category>
+    <image>
+      <url>https://www.louisecerdeira.com/assets/images/apple-touch-icon.png</url>
+      <title>Dr. Louise Cerdeira</title>
+      <link>https://www.louisecerdeira.com/</link>
+    </image>
+    <ttl>1440</ttl>
+
+    <item>
+      <title>Hello, again</title>
+      <link>https://www.louisecerdeira.com/blog/welcome.html</link>
+      <guid isPermaLink="true">https://www.louisecerdeira.com/blog/welcome.html</guid>
+      <pubDate>Fri, 01 May 2026 09:00:00 +0000</pubDate>
+      <dc:creator>Dr. Louise Cerdeira</dc:creator>
+      <category>Personal</category>
+      <description><![CDATA[Reintroducing myself, the site, and the strange continuity between a PhD in São Paulo and a dashboard in London.]]></description>
+    </item>
+
+    <item>
+      <title>Why I'm building a GPU aligner from scratch</title>
+      <link>https://www.louisecerdeira.com/blog/gpu-bioinformatics.html</link>
+      <guid isPermaLink="true">https://www.louisecerdeira.com/blog/gpu-bioinformatics.html</guid>
+      <pubDate>Sun, 22 Mar 2026 09:00:00 +0000</pubDate>
+      <dc:creator>Dr. Louise Cerdeira</dc:creator>
+      <category>Dragon</category>
+      <category>GPU</category>
+      <category>Rust</category>
+      <description><![CDATA[Genomic surveillance shouldn't require an HPC cluster. Notes on Dragon, FM-indices on GPU, and edge bioinformatics for low- and middle-income countries.]]></description>
+    </item>
+
+    <item>
+      <title>What it took to ship AMRnet</title>
+      <link>https://www.louisecerdeira.com/blog/amrnet-launch.html</link>
+      <guid isPermaLink="true">https://www.louisecerdeira.com/blog/amrnet-launch.html</guid>
+      <pubDate>Thu, 15 Jan 2026 09:00:00 +0000</pubDate>
+      <dc:creator>Dr. Louise Cerdeira</dc:creator>
+      <category>AMRnet</category>
+      <category>Research software</category>
+      <description><![CDATA[The years, the rewrites, the people. Lessons on building research software that actually gets used.]]></description>
+    </item>
+  </channel>
+</rss>

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,28 @@
+/* TEAM */
+
+  Owner & author: Dr. Louise Cerdeira
+  Site: https://www.louisecerdeira.com
+  GitHub: @lcerdeira
+  ORCID: 0000-0002-4495-2615
+  Scholar: https://scholar.google.com/citations?user=O2dcz5MAAAAJ
+  Location: United Kingdom · 🇧🇷 originally Brazil
+
+/* THANKS */
+
+  Every co-author from 32+ countries who has ever shared a typhoid,
+  Klebsiella, Salmonella, E. coli, Anopheles, or Wolbachia genome with the
+  public-health community. You make AMRnet, TyphiNET, PlasmidNET, and
+  InfectoNET possible.
+
+/* SITE */
+
+  Last update: 2026/06
+  Standards: HTML5, CSS3, ES2020, WCAG 2.1 AA
+  Components: vanilla HTML, CSS, JS — no framework
+  Hosted: GitHub Pages → custom domain via GoDaddy
+  Fonts: Inter, Newsreader, JetBrains Mono (Google Fonts)
+  Theme: handcrafted (coral · sunshine · mint · lavender)
+  Repository: https://github.com/lcerdeira/portfolio
+  Licence: MIT
+
+  For pleasure without pressure ✦

--- a/index.html
+++ b/index.html
@@ -15,6 +15,43 @@
   <meta name="theme-color" content="#1a1428" media="(prefers-color-scheme: dark)" />
   <meta name="robots" content="index, follow, max-image-preview:large" />
 
+  <!-- Search engine verification — paste your codes between the quotes when you get them.
+       Google Search Console: https://search.google.com/search-console
+       Bing Webmaster Tools:  https://www.bing.com/webmasters
+       Yandex Webmaster:      https://webmaster.yandex.com -->
+  <!-- <meta name="google-site-verification" content="PASTE_GOOGLE_CODE_HERE" /> -->
+  <!-- <meta name="msvalidate.01" content="PASTE_BING_CODE_HERE" /> -->
+  <!-- <meta name="yandex-verification" content="PASTE_YANDEX_CODE_HERE" /> -->
+
+  <!-- RSS feed -->
+  <link rel="alternate" type="application/rss+xml" title="Dr. Louise Cerdeira — Writing" href="/feed.xml" />
+
+  <!-- rel=me for IndieWeb / Mastodon / social verification -->
+  <link rel="me" href="https://github.com/lcerdeira" />
+  <link rel="me" href="https://www.linkedin.com/in/louisecerdeira" />
+  <link rel="me" href="https://x.com/LouiseCerdeira" />
+  <link rel="me" href="https://bsky.app/profile/louisecerdeira.bsky.social" />
+  <link rel="me" href="https://orcid.org/0000-0002-4495-2615" />
+  <link rel="me" href="https://scholar.google.com/citations?user=O2dcz5MAAAAJ" />
+  <link rel="me" href="mailto:louise.cerdeira@gmail.com" />
+
+  <!-- Google Scholar / academic indexing -->
+  <meta name="citation_author" content="Cerdeira, Louise Teixeira" />
+  <meta name="citation_author_orcid" content="0000-0002-4495-2615" />
+  <meta name="citation_author_institution" content="Independent" />
+
+  <!-- Dublin Core (academic metadata) -->
+  <meta name="DC.title" content="Dr. Louise Cerdeira — Computational Biologist & Software Engineer" />
+  <meta name="DC.creator" content="Louise Teixeira Cerdeira" />
+  <meta name="DC.subject" content="Bioinformatics; Computational Biology; Genomic Surveillance; Antimicrobial Resistance; One Health" />
+  <meta name="DC.description" content="Portfolio of Dr. Louise Cerdeira — creator of AMRnet, TyphiNET, PlasmidNET, and InfectoNET." />
+  <meta name="DC.publisher" content="Dr. Louise Cerdeira" />
+  <meta name="DC.type" content="InteractiveResource" />
+  <meta name="DC.format" content="text/html" />
+  <meta name="DC.identifier" content="https://www.louisecerdeira.com/" />
+  <meta name="DC.language" content="en" />
+  <meta name="DC.rights" content="© Dr. Louise Cerdeira" />
+
   <!-- Open Graph -->
   <meta property="og:type" content="profile" />
   <meta property="og:locale" content="en_GB" />
@@ -106,7 +143,84 @@
     "url": "https://www.louisecerdeira.com/",
     "name": "Dr. Louise Cerdeira — Portfolio",
     "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
-    "inLanguage": "en"
+    "inLanguage": "en",
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": "https://www.google.com/search?q=Louise+Cerdeira+{search_term_string}",
+      "query-input": "required name=search_term_string"
+    }
+  }
+  </script>
+
+  <!-- JSON-LD: ProfilePage (Google rich result type for personal sites) -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ProfilePage",
+    "dateModified": "2026-06-04",
+    "mainEntity": {
+      "@type": "Person",
+      "name": "Dr. Louise Cerdeira",
+      "alternateName": "Louise Teixeira Cerdeira",
+      "honorificPrefix": "Dr.",
+      "image": "https://www.louisecerdeira.com/assets/images/profile.jpg",
+      "jobTitle": "Computational Biologist & Lead Software Engineer",
+      "url": "https://www.louisecerdeira.com/",
+      "sameAs": [
+        "https://github.com/lcerdeira",
+        "https://www.linkedin.com/in/louisecerdeira",
+        "https://x.com/LouiseCerdeira",
+        "https://bsky.app/profile/louisecerdeira.bsky.social",
+        "https://orcid.org/0000-0002-4495-2615",
+        "https://scholar.google.com/citations?user=O2dcz5MAAAAJ"
+      ],
+      "description": "Computational biologist and software engineer building open platforms (AMRnet, TyphiNET, PlasmidNET, InfectoNET) for genomic surveillance of antimicrobial resistance."
+    }
+  }
+  </script>
+
+  <!-- JSON-LD: Featured creative works -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "name": "AMRnet",
+        "url": "https://www.amrnet.org",
+        "applicationCategory": "Bioinformatics platform",
+        "operatingSystem": "Web",
+        "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
+        "description": "Open data-visualisation platform for antimicrobial-resistance variants."
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "TyphiNET",
+        "url": "https://www.typhi.net",
+        "applicationCategory": "Bioinformatics platform",
+        "operatingSystem": "Web",
+        "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
+        "description": "Open Salmonella Typhi genomic surveillance dashboard."
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "PlasmidNET",
+        "url": "https://www.plasmidnet.org",
+        "applicationCategory": "Bioinformatics platform",
+        "operatingSystem": "Web",
+        "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
+        "description": "Interactive dashboard for exploring plasmid sequences and mobile genetic elements."
+      },
+      {
+        "@type": "SoftwareApplication",
+        "name": "InfectoNET",
+        "url": "https://www.infectonet.org",
+        "applicationCategory": "Bioinformatics platform",
+        "operatingSystem": "Web",
+        "author": { "@type": "Person", "name": "Dr. Louise Cerdeira" },
+        "description": "Genomic-epidemiology dashboard tracking emerging and re-emerging pathogens worldwide."
+      }
+    ]
   }
   </script>
 </head>
@@ -123,10 +237,10 @@
         <li><a href="#about">About</a></li>
         <li><a href="#research">Research</a></li>
         <li><a href="#collaborations">Map</a></li>
+        <li><a href="#visitors">Visitors</a></li>
         <li><a href="#projects">Projects</a></li>
         <li><a href="#code">Code</a></li>
         <li><a href="#writing">Writing</a></li>
-        <li><a href="#creative">Creative</a></li>
         <li><a href="#contact">Contact</a></li>
       </ul>
     </nav>
@@ -462,10 +576,58 @@
   </div>
 </section>
 
+<!-- ============ VISITORS ============ -->
+<section id="visitors">
+  <div class="container">
+    <p class="section-label" data-reveal>04 — Visitors · Visitantes</p>
+    <h2 data-reveal>You're here.<br><span style="background:linear-gradient(120deg,var(--accent),var(--accent-2),var(--accent-3));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;font-style:italic;">Nice to meet you.</span></h2>
+    <p class="lead" style="max-width: 42rem; margin-bottom: var(--space-7);" data-reveal>
+      A live, privacy-respecting peek at where this site is being read from
+      right now — including yours, if you're curious. Your location appears
+      only to you and is never logged or shared.
+    </p>
+
+    <div class="visitors-grid" data-reveal>
+      <div class="visitor-welcome">
+        <span class="visitor-globe" aria-hidden="true">🌍</span>
+        <h3>You are visiting from</h3>
+        <div class="visitor-loc" id="visitorLoc">
+          <span class="visitor-loading">Detecting</span>
+        </div>
+        <div class="visitor-org" id="visitorOrg"></div>
+        <p class="visitor-greet" id="visitorGreet"></p>
+
+        <p class="visitor-privacy">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Privacy: geo lookup runs in your browser only · no IP stored · no cookies ·
+          counters are anonymous integers
+        </p>
+      </div>
+
+      <div class="visitor-stats-card">
+        <h3 style="font-size: var(--fs-xs); text-transform: uppercase; letter-spacing: 0.18em; color: var(--text-muted); font-family: var(--font-sans); font-weight: 400; margin-bottom: var(--space-5);">Visits so far</h3>
+        <div class="visitor-stat-row">
+          <div class="visitor-stat"><strong id="countTotal">—</strong><span>All-time visits</span></div>
+          <div class="visitor-stat"><strong id="countToday">—</strong><span>Today</span></div>
+          <div class="visitor-stat"><strong id="countCountry">—</strong><span>Your country</span></div>
+          <div class="visitor-stat"><strong id="countContinents">6</strong><span>Continents reached</span></div>
+        </div>
+
+        <p class="visitor-privacy">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M2 12h20M12 2a15.3 15.3 0 0 1 0 20M12 2a15.3 15.3 0 0 0 0 20"/></svg>
+          Look up at the world map — there should be a glowing pin at your
+          approximate location. Visitor counters powered by an open-source,
+          cookieless tally service.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <!-- ============ PROJECTS ============ -->
 <section id="projects" style="background: var(--bg-elev);">
   <div class="container">
-    <p class="section-label" data-reveal>04 — Projects</p>
+    <p class="section-label" data-reveal>05 — Projects</p>
     <h2 data-reveal>Things I've built.</h2>
     <p class="lead" style="max-width: 42rem; margin-bottom: var(--space-7);" data-reveal>
       Open platforms, pipelines, and tools — most of them used in production by public-health
@@ -647,7 +809,7 @@
 <!-- ============ EXPERIENCE ============ -->
 <section id="experience" style="background: var(--bg-elev);">
   <div class="container">
-    <p class="section-label" data-reveal>05 — Experience</p>
+    <p class="section-label" data-reveal>06 — Experience</p>
     <h2 data-reveal>Career, briefly.</h2>
 
     <ol class="timeline" data-reveal>
@@ -688,7 +850,7 @@
 <!-- ============ CODE (GitHub) ============ -->
 <section id="code">
   <div class="container">
-    <p class="section-label" data-reveal>06 — Code</p>
+    <p class="section-label" data-reveal>07 — Code</p>
     <h2 data-reveal>Latest from GitHub.</h2>
     <p class="lead" style="max-width: 42rem;" data-reveal>
       A live feed of my most recently updated public repositories — bioinformatics, web tooling,
@@ -708,7 +870,7 @@
 <!-- ============ WRITING ============ -->
 <section id="writing" style="background: var(--bg-elev);">
   <div class="container">
-    <p class="section-label" data-reveal>07 — Writing</p>
+    <p class="section-label" data-reveal>08 — Writing</p>
     <h2 data-reveal>Notes from the lab and the editor.</h2>
     <p class="lead" style="max-width: 42rem; margin-bottom: var(--space-7);" data-reveal>
       Short essays on the things I actually think about — open science, software engineering for
@@ -748,7 +910,7 @@
 <!-- ============ CREATIVE ============ -->
 <section id="creative">
   <div class="container">
-    <p class="section-label" data-reveal>08 — Off the clock</p>
+    <p class="section-label" data-reveal>09 — Off the clock</p>
     <h2 data-reveal>Photography, poems, and a podcast.</h2>
     <p class="lead" style="max-width: 42rem; margin-bottom: var(--space-7);" data-reveal>
       Outside the terminal I keep a camera, a notebook, and a microphone within reach. Some of what
@@ -817,7 +979,7 @@
 <section id="contact" style="background: var(--bg-elev);">
   <div class="container">
     <div class="contact-card">
-      <p class="section-label" style="justify-content: center; margin-left: auto; margin-right: auto;">09 — Get in touch</p>
+      <p class="section-label" style="justify-content: center; margin-left: auto; margin-right: auto;">10 — Get in touch</p>
       <h2>Let's build something useful.</h2>
       <p class="lead">
         Open to collaborations on genomic surveillance, AMR, public-health platforms, and bioinformatics

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,20 @@
 User-agent: *
 Allow: /
+Disallow: /assets/images/og-image.png
+
+# Be explicit-friendly for AI crawlers that respect robots
+User-agent: GPTBot
+Allow: /
+User-agent: ChatGPT-User
+Allow: /
+User-agent: PerplexityBot
+Allow: /
+User-agent: Google-Extended
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+User-agent: anthropic-ai
+Allow: /
 
 Sitemap: https://www.louisecerdeira.com/sitemap.xml
+Host: https://www.louisecerdeira.com

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,31 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://www.louisecerdeira.com/</loc>
-    <changefreq>monthly</changefreq>
+    <lastmod>2026-06-04</lastmod>
+    <changefreq>weekly</changefreq>
     <priority>1.0</priority>
+    <image:image>
+      <image:loc>https://www.louisecerdeira.com/assets/images/profile.jpg</image:loc>
+      <image:title>Dr. Louise Cerdeira</image:title>
+      <image:caption>Computational Biologist &amp; Software Engineer</image:caption>
+    </image:image>
+    <image:image>
+      <image:loc>https://www.louisecerdeira.com/assets/images/og-image.jpg</image:loc>
+      <image:title>Dr. Louise Cerdeira — Portfolio</image:title>
+    </image:image>
   </url>
   <url>
     <loc>https://www.louisecerdeira.com/blog.html</loc>
+    <lastmod>2026-06-04</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://www.louisecerdeira.com/blog/welcome.html</loc>
     <lastmod>2026-05-01</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.6</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://www.louisecerdeira.com/blog/amrnet-launch.html</loc>
     <lastmod>2026-01-15</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://www.louisecerdeira.com/blog/gpu-bioinformatics.html</loc>
     <lastmod>2026-03-22</lastmod>
     <changefreq>yearly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.8</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## Summary

Two improvements aimed at (1) making the site rank faster for "Louise Cerdeira" searches and (2) giving every visitor a small, joyful, *consensual* "you are here" moment on the world map.

---

## 1. SEO turbo

Everything Google + Bing + Scholar + AI search engines need to put this site at the top of name searches.

- **`ProfilePage` JSON-LD** — Google's newer rich-result type for personal sites
- **`SoftwareApplication` @graph** — AMRnet, TyphiNET, PlasmidNET, InfectoNET surfaced alongside Louise's name in structured-data results
- **Google Scholar citation meta tags** (`citation_author`, `citation_author_orcid`) — boosts academic indexing
- **Dublin Core** meta tags — academic indexers love these
- **RSS feed** (`/feed.xml`) + `<link rel="alternate">` everywhere
- **`<link rel="me">`** to GitHub / LinkedIn / X / Bluesky / ORCID / Scholar / email — Mastodon/IndieWeb verification
- **`BreadcrumbList` JSON-LD** on each blog post — Google shows the breadcrumb under the result
- **Sitemap** now includes `<image:image>` entries, lastmod dates, tuned priorities
- **robots.txt** explicitly allows GPTBot, ClaudeBot, PerplexityBot, Google-Extended, etc. — gets the site into AI search results
- **`humans.txt`** — small classic touch
- **Verification-tag placeholders** with paste-here HTML comments for Google / Bing / Yandex

### What Louise needs to do (once)

1. **Google Search Console**: paste the verification meta tag → uncomment the line in `index.html` → submit `sitemap.xml`
2. **Bing Webmaster Tools**: same flow with the Bing tag
3. (Optional) **Yandex Webmaster** if you want Russian-language reach

The PR description from earlier explains the click-by-click steps.

---

## 2. Visitors map / "you are here"

A new **Visitors · Visitantes** section between Map and Projects.

### What the visitor sees
- A friendly card with their flag, country, city, and institution (when detectable from ISP/ASN)
- A localised hello in their language (14 languages — Olá, Hello, ¡Hola, Bonjour, Hallo, Ciao, こんにちは, 你好, 안녕하세요, नमस्ते, Привет, G'day…)
- A glowing pulse marker added to the world map at their approximate location — in a distinct sunshine colour, alongside the coral collaborator markers
- Anonymous visit counters (all-time + today)
- A clearly visible privacy notice on each card

### Privacy guarantees (real ones, written in the JS file as a comment)
- All geo lookup happens **in the visitor's browser**, never sent to any server we control
- Counter is `abacus.jasoncameron.dev` — open-source, **no cookies, no IP storage**, just an integer per key
- No identifying information is broadcast to other visitors
- The visitor sees their own location; no one else does

### "Institution" detection
Best-effort, transparent: pulls the ISP/org/domain from `ipwho.is` and shows it as "Coming from \<X\>" only if it looks institutional (`.edu`/`.ac`/`.gov` domain, or contains "univ"/"hospital"/"research"/"institute"/"saude"/"fundac"/etc.). Otherwise just shows ISP name. False positives are possible; false sense of surveillance is not — we never store this.

### Perf
- Section work is wrapped in `requestIdleCallback` so it never blocks the main thread
- Graceful fallback if either external service is down

---

## Test plan

- [ ] Open the site, scroll to "Visitors" — your country, city, and ISP should appear
- [ ] Look at the world map — there should be a sunshine-coloured pulse at your location, alongside the coral collaborator pins
- [ ] Reload — counter should increment
- [ ] Try with a VPN — location should update to the VPN endpoint
- [ ] Check Network tab — only `ipwho.is` and `abacus.jasoncameron.dev` requests, no tracking pixels
- [ ] View page source → confirm new `ProfilePage` / `SoftwareApplication` / `citation_author` tags
- [ ] Fetch `/feed.xml` and `/humans.txt` directly — both should render