### PR TITLE
Add featured book card — Montagem ab initio de genoma bacteriano

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1278,6 +1278,116 @@ section { padding: var(--space-9) 0; position: relative; }
   .map-legend { flex-direction: column; align-items: flex-start; }
 }
 
+/* ---------- 22a. Featured book / monograph ---------- */
+.book-card {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: var(--space-6);
+  align-items: center;
+  padding: var(--space-6);
+  margin-top: var(--space-7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background:
+    radial-gradient(ellipse 60% 80% at 0% 0%, color-mix(in srgb, var(--accent-warm) 14%, transparent), transparent 60%),
+    radial-gradient(ellipse 80% 50% at 100% 100%, color-mix(in srgb, var(--accent-4) 14%, transparent), transparent 60%),
+    var(--bg-elev);
+  position: relative;
+  overflow: hidden;
+}
+@media (max-width: 720px) {
+  .book-card { grid-template-columns: 1fr; }
+  .book-cover { justify-self: center; }
+}
+
+.book-cover {
+  position: relative;
+  width: 200px; height: 280px;
+  perspective: 800px;
+  filter: drop-shadow(0 12px 24px rgba(45, 27, 78, 0.18));
+  transition: transform var(--dur) var(--ease);
+}
+.book-cover:hover { transform: translateY(-4px) rotate(-1deg); }
+.book-cover-inner {
+  position: absolute;
+  inset: 0;
+  border-radius: 4px 8px 8px 4px;
+  background:
+    linear-gradient(135deg, var(--accent-warm) 0%, var(--accent) 50%, var(--accent-4) 100%);
+  color: #fff;
+  padding: var(--space-5) var(--space-4) var(--space-4) var(--space-5);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  transform: rotateY(-6deg);
+  transform-origin: left center;
+}
+.book-cover-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  opacity: 0.85;
+}
+.book-cover-title {
+  font-family: var(--font-serif);
+  font-size: 1.55rem;
+  font-weight: 500;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+}
+.book-cover-title em { font-style: italic; opacity: 0.92; }
+.book-cover-author {
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.9;
+}
+.book-spine {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 6px;
+  background: linear-gradient(to right, rgba(0,0,0,0.25), transparent);
+  border-radius: 4px 0 0 4px;
+  transform: rotateY(-6deg);
+  transform-origin: left center;
+}
+
+.book-label {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+  display: inline-block;
+  margin-bottom: var(--space-3);
+}
+.book-body h3 {
+  font-size: var(--fs-xl);
+  margin-bottom: var(--space-1);
+}
+.book-body h3 em { color: var(--accent-warm); font-style: italic; }
+.book-subtitle {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--fs-md);
+  color: var(--text-muted);
+  margin: 0 0 var(--space-4);
+}
+.book-desc {
+  font-size: var(--fs-sm);
+  margin-bottom: var(--space-4);
+}
+.book-meta {
+  display: flex; flex-wrap: wrap; gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+.book-links {
+  display: flex; gap: var(--space-3); flex-wrap: wrap;
+  margin: 0;
+}
+
 /* ---------- 22. Visitor map / "you are here" ---------- */
 .visitor-marker .core,
 .visitor-marker .ring {

--- a/index.html
+++ b/index.html
@@ -179,6 +179,27 @@
   }
   </script>
 
+  <!-- JSON-LD: Book -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Book",
+    "name": "Montagem ab initio de genoma bacteriano: utilizando sequências curtas pareadas",
+    "alternativeHeadline": "Ab initio bacterial genome assembly using short paired-end reads",
+    "author": {
+      "@type": "Person",
+      "name": "Louise Teixeira Cerdeira",
+      "url": "https://www.louisecerdeira.com/"
+    },
+    "inLanguage": "pt-BR",
+    "bookFormat": "https://schema.org/Paperback",
+    "isbn": "9783639684902",
+    "publisher": { "@type": "Organization", "name": "Novas Edições Acadêmicas" },
+    "about": ["Bioinformatics", "Bacterial genome assembly", "Next-generation sequencing", "Short reads"],
+    "url": "https://www.amazon.co.uk/Montagem-initio-genoma-bacteriano-utilizando/dp/3639684907"
+  }
+  </script>
+
   <!-- JSON-LD: Featured creative works -->
   <script type="application/ld+json">
   {
@@ -412,6 +433,40 @@
           (<a href="https://github.com/lcerdeira/dragon" target="_blank" rel="noopener">Dragon</a>,
           <a href="https://github.com/lcerdeira/CNVRock" target="_blank" rel="noopener">CNVRock</a>)
           so sequencing analysis doesn't need a HPC cluster.</p>
+      </div>
+    </div>
+
+    <div class="book-card" data-reveal>
+      <div class="book-cover" aria-hidden="true">
+        <div class="book-cover-inner">
+          <span class="book-cover-eyebrow">monografia · MSc</span>
+          <span class="book-cover-title">Montagem<br><em>ab initio</em><br>de genoma<br>bacteriano</span>
+          <span class="book-cover-author">Louise Cerdeira</span>
+        </div>
+        <span class="book-spine" aria-hidden="true"></span>
+      </div>
+      <div class="book-body">
+        <span class="book-label">Book · Monograph · Portuguese</span>
+        <h3>Montagem <em>ab initio</em> de genoma bacteriano</h3>
+        <p class="book-subtitle">utilizando sequências curtas pareadas</p>
+        <p class="book-desc">
+          A monograph (based on my MSc work) demonstrating that bacterial genomes can be
+          assembled <em>ab initio</em> from short 25-nucleotide paired-end reads — one of the foundational
+          bioinformatics challenges of the early NGS era, and where my long love affair with
+          microbial genomics began.
+        </p>
+        <div class="book-meta">
+          <span class="tag">Bioinformatics</span>
+          <span class="tag">NGS</span>
+          <span class="tag">Bacterial genomics</span>
+          <span class="tag">ISBN 978-3-639-68490-2</span>
+        </div>
+        <p class="book-links">
+          <a class="btn btn-primary" href="https://www.amazon.co.uk/Montagem-initio-genoma-bacteriano-utilizando/dp/3639684907" target="_blank" rel="noopener">
+            Buy on Amazon UK <span class="arrow">→</span>
+          </a>
+          <a class="btn btn-ghost" href="https://www.amazon.com.br/Montagem-ab-initio-genoma-bacteriano/dp/3639684907" target="_blank" rel="noopener">Amazon Brasil</a>
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

Showcases Louise's monograph (Portuguese, ISBN 978-3-639-68490-2,
published by Novas Edições Acadêmicas) as a featured card in the
**Research** section, between the four research areas and the Selected
publications list — the natural spot for a scholarly book on an
academic site.

This commit was pushed after PR #29 was already merged, so it needs its
own PR. Single commit, single feature.

## What's added

- **Book card** in `index.html` — stylised 3D-tilt cover with gradient,
  title, Portuguese subtitle, description, ISBN tag, and Amazon UK /
  Brasil buy links
- **Book JSON-LD** schema in `<head>` — Google can now associate the
  book with Louise's name in search results (potential rich-result
  with cover thumbnail)
- **CSS** for the book card (responsive: cover stacks above body on
  mobile)

## What the visitor sees

In the Research section:

> **BOOK · MONOGRAPH · PORTUGUESE**
> ### Montagem *ab initio* de genoma bacteriano
> *utilizando sequências curtas pareadas*
>
> A monograph (based on my MSc work) demonstrating that bacterial
> genomes can be assembled *ab initio* from short 25-nucleotide
> paired-end reads — one of the foundational bioinformatics challenges
> of the early NGS era, and where my long love affair with microbial
> genomics began.
>
> [Bioinformatics] [NGS] [Bacterial genomics] [ISBN 978-3-639-68490-2]
>
> [Buy on Amazon UK →] [Amazon Brasil]

## Test plan

- [ ] Scroll to the Research section — book card renders between the
      research areas and the publications list
- [ ] Hover the cover — slight lift and tilt
- [ ] Click "Buy on Amazon UK" — opens
      https://www.amazon.co.uk/Montagem-initio-genoma-bacteriano-utilizando/dp/3639684907
- [ ] On mobile, cover stacks above body
- [ ] View source — Book JSON-LD present in <head>