### PR TITLE
Simplify book card — remove broken cover and Amazon Brasil link

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1280,10 +1280,6 @@ section { padding: var(--space-9) 0; position: relative; }
 
 /* ---------- 22a. Featured book / monograph ---------- */
 .book-card {
-  display: grid;
-  grid-template-columns: 200px 1fr;
-  gap: var(--space-6);
-  align-items: center;
   padding: var(--space-6);
   margin-top: var(--space-7);
   border: 1px solid var(--border);
@@ -1294,64 +1290,11 @@ section { padding: var(--space-9) 0; position: relative; }
     var(--bg-elev);
   position: relative;
   overflow: hidden;
+  transition: border-color var(--dur) var(--ease), transform var(--dur) var(--ease);
 }
-@media (max-width: 720px) {
-  .book-card { grid-template-columns: 1fr; }
-  .book-cover { justify-self: center; }
-}
-
-.book-cover {
-  position: relative;
-  width: 200px; height: 280px;
-  perspective: 800px;
-  filter: drop-shadow(0 12px 24px rgba(45, 27, 78, 0.18));
-  transition: transform var(--dur) var(--ease);
-}
-.book-cover:hover { transform: translateY(-4px) rotate(-1deg); }
-.book-cover-inner {
-  position: absolute;
-  inset: 0;
-  border-radius: 4px 8px 8px 4px;
-  background:
-    linear-gradient(135deg, var(--accent-warm) 0%, var(--accent) 50%, var(--accent-4) 100%);
-  color: #fff;
-  padding: var(--space-5) var(--space-4) var(--space-4) var(--space-5);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  transform: rotateY(-6deg);
-  transform-origin: left center;
-}
-.book-cover-eyebrow {
-  font-family: var(--font-mono);
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.2em;
-  opacity: 0.85;
-}
-.book-cover-title {
-  font-family: var(--font-serif);
-  font-size: 1.55rem;
-  font-weight: 500;
-  line-height: 1.05;
-  letter-spacing: -0.01em;
-}
-.book-cover-title em { font-style: italic; opacity: 0.92; }
-.book-cover-author {
-  font-family: var(--font-sans);
-  font-size: 0.75rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  opacity: 0.9;
-}
-.book-spine {
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  width: 6px;
-  background: linear-gradient(to right, rgba(0,0,0,0.25), transparent);
-  border-radius: 4px 0 0 4px;
-  transform: rotateY(-6deg);
-  transform-origin: left center;
+.book-card:hover {
+  border-color: var(--accent-warm);
+  transform: translateY(-2px);
 }
 
 .book-label {

--- a/index.html
+++ b/index.html
@@ -437,14 +437,6 @@
     </div>
 
     <div class="book-card" data-reveal>
-      <div class="book-cover" aria-hidden="true">
-        <div class="book-cover-inner">
-          <span class="book-cover-eyebrow">monografia · MSc</span>
-          <span class="book-cover-title">Montagem<br><em>ab initio</em><br>de genoma<br>bacteriano</span>
-          <span class="book-cover-author">Louise Cerdeira</span>
-        </div>
-        <span class="book-spine" aria-hidden="true"></span>
-      </div>
       <div class="book-body">
         <span class="book-label">Book · Monograph · Portuguese</span>
         <h3>Montagem <em>ab initio</em> de genoma bacteriano</h3>
@@ -465,7 +457,6 @@
           <a class="btn btn-primary" href="https://www.amazon.co.uk/Montagem-initio-genoma-bacteriano-utilizando/dp/3639684907" target="_blank" rel="noopener">
             Buy on Amazon UK <span class="arrow">→</span>
           </a>
-          <a class="btn btn-ghost" href="https://www.amazon.com.br/Montagem-ab-initio-genoma-bacteriano/dp/3639684907" target="_blank" rel="noopener">Amazon Brasil</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Two requested cleanups on the featured book card in the Research section:

1. **Removed the stylised "book cover"** — the 3D-tilt gradient cover
   element was rendering as plain unformatted text on the live site
   instead of the intended visual cover. Removed entirely.
2. **Removed the Amazon Brasil secondary button** — keeping only the
   primary "Buy on Amazon UK" call-to-action.

## What the card looks like now

```
BOOK · MONOGRAPH · PORTUGUESE
Montagem ab initio de genoma bacteriano
utilizando sequências curtas pareadas

[Description paragraph]

[Bioinformatics] [NGS] [Bacterial genomics] [ISBN 978-3-639-68490-2]

[Buy on Amazon UK →]
```

Single-column layout, full-width card, subtle hover lift, warm
sunset-coral / lavender background glow preserved.

## What's removed

- `<div class="book-cover">` block (cover-inner, eyebrow, title, author,
  spine spans)
- Amazon Brasil `<a class="btn btn-ghost">` link
- All `.book-cover*` and `.book-spine` CSS rules
- Two-column grid layout (no longer needed)

## Test plan

- [ ] Open the live site, scroll to Research → book card
- [ ] No "monografia · MSc" / "Louise Cerdeira" plain text above the
      styled card content
- [ ] Only one CTA button visible: "Buy on Amazon UK →"
- [ ] Hover the card → small lift + warmer border colour